### PR TITLE
Update commit message format with extra newline

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9714,7 +9714,7 @@ async function run() {
           !commit.message.startsWith("Merge") &&
           !bugzillaRegExp.test(commit.message)) {
         const body = `🚧 Commit message is using the wrong format: _${commit.message}_\n\nThe comment message should look like:\n
-        Bug xxxx - Short description of your change
+        Bug xxxx - Short description of your change\n
         Optionally, a longer description of the change.
         `;
 

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ async function run() {
           !commit.message.startsWith("Merge") &&
           !bugzillaRegExp.test(commit.message)) {
         const body = `🚧 Commit message is using the wrong format: _${commit.message}_\n\nThe comment message should look like:\n
-        Bug xxxx - Short description of your change
+        Bug xxxx - Short description of your change\n
         Optionally, a longer description of the change.
         `;
 


### PR DESCRIPTION
In a git commit message an extra newline is needed to separate the summary from the body of the message. Without it, this leads to formatting that appends title to body. 

We should fixup our recommendation to use the appropriate format.

Here is an example where the last commit message has no new line between the title and the body and causes it to be recognized as one line ([reference PR](https://github.com/mozilla-mobile/firefox-android/pull/890) for comparison):

<img width="892" alt="Screenshot 2023-02-23 at 6 33 08 PM" src="https://user-images.githubusercontent.com/1370580/221055790-9a46741b-15c2-4f96-9fa2-bd7b0b702d39.png">
